### PR TITLE
fix: set ulimit by default in startup strategy

### DIFF
--- a/src/main/java/org/testcontainers/containers/CephContainer.java
+++ b/src/main/java/org/testcontainers/containers/CephContainer.java
@@ -61,8 +61,6 @@ public class CephContainer extends GenericContainer<CephContainer> {
     public CephContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-        setWaitStrategy(Wait.forLogMessage(String.format(CEPH_END_START_REGEX_FORMAT, this.cephBucket), 1)
-                .withStartupTimeout(Duration.ofMinutes(5)));
         withCreateContainerCmdModifier(createContainerCmd ->
                 requireNonNull(createContainerCmd
                         .getHostConfig())
@@ -97,6 +95,10 @@ public class CephContainer extends GenericContainer<CephContainer> {
         addEnv("MON_IP", "127.0.0.1");
         // This is important because without it, we cant access ceph from http://localhost:<PORT>
         addEnv("RGW_NAME", "localhost");
+        if (this.waitStrategy == DEFAULT_WAIT_STRATEGY) {
+            setWaitStrategy(Wait.forLogMessage(String.format(CEPH_END_START_REGEX_FORMAT, this.cephBucket), 1)
+                    .withStartupTimeout(Duration.ofMinutes(5)));
+        }
     }
 
     public CephContainer withSslDisabled() {

--- a/src/test/java/org/testcontainers/containers/CephContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/CephContainerTest.java
@@ -2,6 +2,8 @@ package org.testcontainers.containers;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -149,6 +151,24 @@ public class CephContainerTest {
         }
     }
 
+    @Test
+    void testOverrideStartupStrategy() {
+        DockerImageName daemonImage =
+                DockerImageName.parse("quay.io/ceph/daemon:v7.0.3-stable-7.0-quincy-centos-stream8-x86_64")
+                        .asCompatibleSubstituteFor("quay.io/ceph/demo");
+        try (
+                CephContainer container = new CephContainer(daemonImage)
+                        .withCephAccessKey("testuser123")
+                        .withCephSecretKey("testpassword123")
+                        .withCephBucket("testbucket123")
+                        .withCommand("demo");
+        ) {
+            container.setWaitStrategy(Wait.forListeningPort());
+            container.start();
+            assertThat(container.isRunning()).isTrue();
+            assertThat(container.getWaitStrategy()).isInstanceOf(HostPortWaitStrategy.class);
+        }
+    }
 
     // configuringClient {
 


### PR DESCRIPTION
fix https://github.com/jarlah/testcontainers-ceph/issues/176 and set ulimit so startup time is reduced on platforms that support it.

This has been built and tested on an pc running manjaro.