### PR TITLE
Allow customizing RGW_NAME (fixes #216), bundle dependabot bumps, add Nix dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,1 @@
-if has nix && [ -f flake.nix ]; then
-  use flake
-elif has nix && [ -f shell.nix ]; then
-  use nix
-fi
+use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+if has nix && [ -f flake.nix ]; then
+  use flake
+elif has nix && [ -f shell.nix ]; then
+  use nix
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 target/
 # the tests copy the demo file from the container
 demo-script
+# direnv local cache for the Nix dev shell
+.direnv/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Testcontainers Ceph
 
 ![main](https://github.com/jarlah/testcontainers-ceph/actions/workflows/maven.yml/badge.svg?branch=main)
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.jarlah/testcontainers-ceph/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.jarlah/testcontainers-ceph)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.jarlah/testcontainers-ceph?logo=apachemaven)](https://central.sonatype.com/artifact/io.github.jarlah/testcontainers-ceph)
 
 A [Testcontainers](https://www.testcontainers.org/) implementation for [Ceph](https://ceph.io).
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "testcontainers-ceph — Java development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        jdk = pkgs.jdk11;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            jdk
+            pkgs.maven
+            pkgs.docker-client
+          ];
+
+          shellHook = ''
+            export JAVA_HOME=${jdk.home}
+          '';
+        };
+      });
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.11.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     </properties>
 
@@ -148,49 +148,49 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>2.29.24</version>
+            <version>2.30.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.12</version>
+            <version>1.5.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.12</version>
+            <version>1.5.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.16</version>
+            <version>2.0.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.11.3</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.26.3</version>
+            <version>3.27.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  jdk = pkgs.jdk11;
+in
+pkgs.mkShell {
+  packages = [
+    jdk
+    pkgs.maven
+    pkgs.docker-client
+  ];
+
+  JAVA_HOME = jdk.home;
+}

--- a/src/main/java/org/testcontainers/containers/CephContainer.java
+++ b/src/main/java/org/testcontainers/containers/CephContainer.java
@@ -40,6 +40,8 @@ public class CephContainer extends GenericContainer<CephContainer> {
 
     private static final String CEPH_DEMO_BUCKET = "demo";
 
+    private static final String CEPH_RGW_DEFAULT_NAME = "localhost";
+
     private static final String CEPH_END_START_REGEX_FORMAT = ".*Bucket 's3://%s/' created\n.*";
 
     private static final Ulimit[] DEFAULT_ULIMITS = new Ulimit[]{new Ulimit("nofile", 65536L, 65536L)};
@@ -49,6 +51,8 @@ public class CephContainer extends GenericContainer<CephContainer> {
     private String cephSecretKey;
 
     private String cephBucket;
+
+    private String rgwName;
 
     public CephContainer() {
         this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_IMAGE_TAG));
@@ -104,8 +108,16 @@ public class CephContainer extends GenericContainer<CephContainer> {
         addEnv("CEPH_PUBLIC_NETWORK", "0.0.0.0/0");
         // This needs to be 127.0.0.1, if not the demo image will not start properly
         addEnv("MON_IP", "127.0.0.1");
-        // This is important because without it, we cant access ceph from http://localhost:<PORT>
-        addEnv("RGW_NAME", "localhost");
+        // Default "localhost" lets callers on the host access the RGW via the
+        // container's mapped port. Override via withRgwName(...) when you need
+        // another container on the same Docker network to reach this one by
+        // network alias — see issue #216 for the tradeoff.
+        addEnv(
+                "RGW_NAME",
+                this.rgwName != null
+                        ? this.rgwName
+                        : (this.rgwName = CEPH_RGW_DEFAULT_NAME)
+        );
         if (this.waitStrategy == DEFAULT_WAIT_STRATEGY) {
             setWaitStrategy(Wait.forLogMessage(String.format(CEPH_END_START_REGEX_FORMAT, this.cephBucket), 1)
                     .withStartupTimeout(Duration.ofMinutes(5)));
@@ -139,6 +151,23 @@ public class CephContainer extends GenericContainer<CephContainer> {
         return this;
     }
 
+    /**
+     * Override the {@code RGW_NAME} env var passed to the Ceph demo image.
+     * <br>
+     * The default, {@code "localhost"}, is what you want when the code under
+     * test runs on the host and reaches Ceph via the container's mapped port.
+     * <br>
+     * Set this to the container's network alias (or hostname) when another
+     * container on the same Docker network needs to reach Ceph by name.
+     * Note: setting this to something other than {@code "localhost"} will
+     * break host-based access via {@link #getCephUrl()} — you cannot have
+     * both access paths active at the same time with the demo image.
+     */
+    public CephContainer withRgwName(String rgwName) {
+        this.rgwName = rgwName;
+        return this;
+    }
+
     public int getCephPort() {
         return getMappedPort(CEPH_RGW_DEFAULT_PORT);
     }
@@ -157,5 +186,9 @@ public class CephContainer extends GenericContainer<CephContainer> {
 
     public String getCephBucket() {
         return cephBucket;
+    }
+
+    public String getRgwName() {
+        return rgwName;
     }
 }

--- a/src/test/java/org/testcontainers/containers/CephContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/CephContainerTest.java
@@ -9,6 +9,8 @@ import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -174,6 +176,34 @@ class CephContainerTest {
     }
 
     /**
+     * Default RGW_NAME is "localhost" so callers on the host can reach Ceph
+     * via the container's mapped port.
+     * Regression check for issue<a href="https://github.com/jarlah/testcontainers-ceph/issues/216"> #216</a>
+     */
+    @Test
+    void testDefaultRgwNameIsLocalhost() {
+        try (CephContainer container = new CephContainer()) {
+            container.configure();
+            assertThat(container.getRgwName()).isEqualTo("localhost");
+            assertThat(container.getEnvMap()).containsEntry("RGW_NAME", "localhost");
+        }
+    }
+
+    /**
+     * {@code withRgwName(...)} lets callers override RGW_NAME so another
+     * container on the same Docker network can reach Ceph by alias.
+     * Issue<a href="https://github.com/jarlah/testcontainers-ceph/issues/216"> #216</a>
+     */
+    @Test
+    void testWithRgwNameOverride() {
+        try (CephContainer container = new CephContainer().withRgwName("ceph-host")) {
+            container.configure();
+            assertThat(container.getRgwName()).isEqualTo("ceph-host");
+            assertThat(container.getEnvMap()).containsEntry("RGW_NAME", "ceph-host");
+        }
+    }
+
+    /**
      * Test that WaitingFor override works
      * Keep validating issue<a href="https://github.com/jarlah/testcontainers-ceph/issues/176"> #176</a>
      */
@@ -202,10 +232,15 @@ class CephContainerTest {
                 container.getCephSecretKey()
         );
         final StaticCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(credentials);
+        // AWS SDK 2.30+ defaults to WHEN_SUPPORTED, which adds flexible-checksum
+        // headers to PutObject. Older Ceph RGW (latest-quincy / v17) rejects
+        // those with HTTP 400, so opt in only when required.
         return S3Client.builder()
                 .credentialsProvider(credentialsProvider)
                 .endpointOverride(container.getCephUrl())
                 .region(Region.US_EAST_1)
+                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
                         .build())


### PR DESCRIPTION
Resolves issue #216 and consolidates the 10 open dependabot PRs into a single merge.

## 1. RGW_NAME override (fixes #216)

Before: `configure()` hardcoded `addEnv("RGW_NAME", "localhost")` — fine for host-based access via the container's mapped port, but broken when another container on the same Docker network wants to reach Ceph by its network alias (it sees `localhost` as the bucket hostname and fails with "Specified Bucket does not exist").

Adds:
- `withRgwName(String)` builder method
- `getRgwName()` getter
- Javadoc explaining the tradeoff: you can't have both access paths active with the demo image, so users pick one

Default stays `"localhost"` — existing users unaffected.

## 2. Dependency bumps (closes #187, #201, #209, #210, #211, #212, #213, #214, #215; supersedes #207)

Applied directly to `pom.xml` in one commit to avoid 10 separate rebases:
- aws-sdk s3 2.29.24 → 2.30.32
- logback-core/classic 1.5.12 → 1.5.17
- slf4j-api 2.0.16 → 2.0.17
- junit-jupiter-engine 5.11.3 → 5.12.0
- assertj-core 3.26.3 → 3.27.3
- jackson-core/annotations 2.18.2 → 2.18.3
- maven-javadoc-plugin 3.11.1 → 3.11.2

PR #207 (testcontainers 1.20.4 → 1.20.5) is superseded — master is already on 2.0.1.

**One test adjustment needed**: AWS SDK 2.30+ defaults to `WHEN_SUPPORTED` for flexible-checksum headers on PutObject. The `latest-quincy` (v17) Ceph demo image used in `testBasicUsage` rejects those with HTTP 400, so the test's S3 client now sets `requestChecksumCalculation=WHEN_REQUIRED` / `responseChecksumValidation=WHEN_REQUIRED`. The `latest` image used in `testOverrides` handles them fine, so no change needed there.

## 3. Nix development shell

`flake.nix` / `shell.nix` / `.envrc` providing JDK 11, Maven 3.9, and docker-client. Drops into `nix develop` (or direnv auto-activation) without touching host package state.

## 4. README badge

`maven-badges.herokuapp.com` went offline when Heroku retired the free tier. Replaced with shields.io's `maven-central/v` badge pointing to Sonatype Central.

## Test plan
- [x] `mvn test` — 7/7 passing (2 new unit tests for RGW_NAME override + default, 5 existing integration tests still green)
- [x] `mvn compile` clean under JDK 11 + bumped deps
- [x] Nix flake evaluates and the shell has JDK 11 + Maven + docker-client

## Closes

- Closes #216 (RGW_NAME feature)
- Closes #187, #201, #209, #210, #211, #212, #213, #214, #215 (superseded by bumps in commit 2)
- PR #207 can be closed as superseded (testcontainers already 2.0.1)