### PR TITLE
Auto-tag release and bump next snapshot in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,16 +3,44 @@ on:
   workflow_dispatch:
     inputs:
       releaseversion:
-        description: 'Release version'
+        description: 'Release version (e.g. 2.0.8)'
+        required: true
+        default: ''
+      nextSnapshotVersion:
+        description: 'Next snapshot version (e.g. 2.0.9-SNAPSHOT)'
         required: true
         default: ''
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Required so the workflow can push the release commit + tag and the
+    # subsequent next-snapshot bump back to main.
+    permissions:
+      contents: write
     steps:
-      - run: echo "Will start a Maven Central upload with version ${{ github.event.inputs.releaseversion }}"
+      - run: echo "Will release ${{ github.event.inputs.releaseversion }} and then bump main to ${{ github.event.inputs.nextSnapshotVersion }}"
 
       - uses: actions/checkout@v4
+        with:
+          # Fetch full history so tags and pushes aren't blocked by a shallow clone.
+          fetch-depth: 0
+          # Use the default GITHUB_TOKEN for subsequent git operations.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Guard — must be dispatched from main
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "This workflow must be run from the 'main' branch (got: ${{ github.ref }})." >&2
+            echo "Re-dispatch with 'Use workflow from' set to Branch: main." >&2
+            exit 1
+          fi
+
+      - name: Guard — release tag must not already exist
+        run: |
+          if git rev-parse "v${{ github.event.inputs.releaseversion }}" >/dev/null 2>&1; then
+            echo "Tag v${{ github.event.inputs.releaseversion }} already exists. Pick a new version." >&2
+            exit 1
+          fi
 
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v4
@@ -25,8 +53,13 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Set projects Maven version to GitHub Action GUI set version
-        run: mvn --batch-mode versions:set "-DnewVersion=${{ github.event.inputs.releaseversion }}"
+      - name: Configure git author for release commits
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Set project version to release version
+        run: mvn --batch-mode versions:set "-DnewVersion=${{ github.event.inputs.releaseversion }}" -DgenerateBackupPoms=false
 
       - name: Publish package
         run: mvn --batch-mode clean deploy -P central-deploy -DskipTests=true
@@ -34,3 +67,21 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      # From here on the artifact is on Maven Central. Record it in git so the
+      # tag's source tree matches what shipped, then bump main for the next
+      # development iteration. These steps run only if the deploy succeeded.
+
+      - name: Commit release pom.xml and push tag + commit atomically
+        run: |
+          git add pom.xml
+          git commit -m "Release ${{ github.event.inputs.releaseversion }}"
+          git tag -a "v${{ github.event.inputs.releaseversion }}" -m "Release ${{ github.event.inputs.releaseversion }}"
+          git push --atomic origin main "v${{ github.event.inputs.releaseversion }}"
+
+      - name: Bump to next snapshot version and push
+        run: |
+          mvn --batch-mode versions:set "-DnewVersion=${{ github.event.inputs.nextSnapshotVersion }}" -DgenerateBackupPoms=false
+          git add pom.xml
+          git commit -m "Prepare for next development iteration: ${{ github.event.inputs.nextSnapshotVersion }}"
+          git push origin main


### PR DESCRIPTION
Makes the release pipeline do everything in one click — deploy, tag, bump — instead of leaving gaps you have to plug manually.

## What changed

Before: the workflow set pom.xml to the release version *inside the runner only*, published to Maven Central, then exited. Nothing landed back in the repo. As a result:

- Tags had to be created by hand (you did this via GitHub releases)
- Even then, the tag's source tree still said `X.Y.Z-SNAPSHOT` — checking out the tag locally builds something that doesn't match what's on Maven Central
- Main never got bumped to the next snapshot, so subsequent snapshot builds reused the released version's number

After: one `workflow_dispatch` run does everything.

## New flow

1. **Two required inputs** now: `releaseversion` (e.g. `2.0.8`) and `nextSnapshotVersion` (e.g. `2.0.9-SNAPSHOT`).
2. **Dispatch guard**: the workflow refuses to run unless dispatched from `main`. Tells you exactly what to change if you picked the wrong ref.
3. **Duplicate-tag guard**: if `vX.Y.Z` already exists, the workflow refuses up front rather than blowing up halfway through.
4. **Deploy to Maven Central** (unchanged from before).
5. **Post-deploy, on success only**: commit the release pom.xml (`Release 2.0.8`), create annotated tag `v2.0.8`, push commit + tag atomically to main.
6. **Then bump**: set pom.xml to the next snapshot, commit (`Prepare for next development iteration: 2.0.9-SNAPSHOT`), push to main.

Runner permissions: `contents: write` on the job. Uses the default `GITHUB_TOKEN` — no PAT or bot account needed. Works because main isn't branch-protected (if that changes, we'd swap step 5/6 for a `peter-evans/create-pull-request` based PR flow).

## Rollback behavior

- If deploy fails → nothing is committed or tagged. Runner state is ephemeral.
- If tag push fails after deploy succeeds → artifact is on Central, but main is untouched. Manual fix: create the tag locally at HEAD, push it; then re-dispatch with the next snapshot version unchanged (it'll skip the tag step via the duplicate-tag guard). Or tag by hand.
- If next-snapshot push fails after tag+commit succeeded → tag + release commit are on GitHub, just bump the pom.xml manually and push.

Atomic `git push --atomic origin main vX.Y.Z` on the release step ensures commit and tag either both land or neither does.

## Test plan

This is unrunnable in CI without actually publishing, so I can't smoke-test it without pushing a real release. Suggested first use:

1. Merge this PR
2. Run `release-to-maven-central` workflow from main with `releaseversion=2.0.8` and `nextSnapshotVersion=2.0.9-SNAPSHOT`
3. After it succeeds: confirm `v2.0.8` tag exists, main has two new commits (release + next-dev), and Maven Central has 2.0.8

If something goes wrong mid-release, the rollback section above covers the recovery paths.