### PR TITLE
Fix Javadoc errors blocking the release pipeline

### DIFF
--- a/src/main/java/org/testcontainers/containers/CephContainer.java
+++ b/src/main/java/org/testcontainers/containers/CephContainer.java
@@ -78,9 +78,9 @@ public class CephContainer extends GenericContainer<CephContainer> {
     }
 
     /**
-     * @Override default configure of generic container
-     * set necessary env variables for Ceph
-     * Set wait strategy to wait for log if not set
+     * Overrides the default configure() from GenericContainer to set the
+     * environment variables Ceph needs and to install a log-based wait
+     * strategy when none has been set explicitly.
      */
     @Override
     public void configure() {
@@ -162,6 +162,9 @@ public class CephContainer extends GenericContainer<CephContainer> {
      * Note: setting this to something other than {@code "localhost"} will
      * break host-based access via {@link #getCephUrl()} — you cannot have
      * both access paths active at the same time with the demo image.
+     *
+     * @param rgwName the hostname the RGW should advertise itself as
+     * @return this container for chaining
      */
     public CephContainer withRgwName(String rgwName) {
         this.rgwName = rgwName;


### PR DESCRIPTION
The `release-to-maven-central` workflow (merged in #220) ran for the first time and failed in the `Publish package` step. Diagnosis:

```
Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:jar (attach-javadocs)
on project testcontainers-ceph: MavenReportException: Error while generating Javadoc:

CephContainer.java:81: error: unknown tag: Override
     * @Override default configure of generic container
CephContainer.java:166: warning: no @param for rgwName
CephContainer.java:166: warning: no @return
```

## Root causes

1. **My bug**: the `withRgwName(String rgwName)` method I added in [74b70b8](https://github.com/jarlah/testcontainers-ceph/commit/74b70b8) had no `@param` or `@return` Javadoc tags. The javadoc plugin treats missing tags as errors under default doclint.

2. **Pre-existing**: line 81's comment had `@Override` sitting inside a Javadoc block. `@Override` is a Java annotation, not a Javadoc tag — javadoc reports `unknown tag: Override` as an error. This snuck past for years because the publish workflow had never actually been run (0 prior runs confirmed in the Actions history); releases were presumably done locally where `central-deploy` wasn't exercised.

## Fix

1. Add missing `@param rgwName` / `@return` to `withRgwName`.
2. Reword line 81's comment to use prose instead of the misused annotation.

## Verification

Couldn't run the full `central-deploy` profile locally (GPG signing setup), but ran the javadoc goal at the exact pinned version:

```
mvn org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:jar
→ BUILD SUCCESS
```

## Recovery state (no cleanup needed)

Checked before pushing this fix:
- `main` pom.xml: still `2.0.8-SNAPSHOT` ✓ (deploy failed before the commit step)
- No `v2.0.8` tag on origin ✓ (tag step never ran)
- Latest tag is still `2.0.7`

So re-running the workflow after this merge with the same `releaseversion=2.0.8` / `nextSnapshotVersion=2.0.9-SNAPSHOT` will pass the guards cleanly.

## Follow-up thoughts

This surfaced a broader question: if a future run fails after the release commit+tag push succeeded but before the next-snapshot bump, the repo would be left in a slightly awkward state and the current guards would block re-run. Worth adding idempotency later (e.g. "if tag already exists, skip that step"). Happy to open a follow-up if you want — but for this specific failure there's nothing stuck.