### PR TITLE
Migrate publish pipeline to Central Portal

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,7 +44,9 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-          server-id: s01.oss.sonatype.org
+          # `central` matches <publishingServerId> in pom.xml; the legacy
+          # `s01.oss.sonatype.org` host is dead (OSSRH was sunset 2025-06-30).
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -151,8 +153,11 @@ jobs:
         if: steps.state.outputs.tag_exists != 'true' && github.event.inputs.skipDeploy != 'true'
         run: mvn --batch-mode clean deploy -P central-deploy -DskipTests=true
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          # Central Portal user token (generate at central.sonatype.com → View
+          # Account → Generate User Token). Both values are random strings;
+          # neither is your account email or password.
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       # From here on the artifact is on Maven Central. Record it in git so the

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
-        <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     </properties>
 
 
@@ -104,24 +104,23 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>s01.oss.sonatype.org</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <!-- Matches the <id> in settings.xml; setup-java in
+                                 publish.yaml writes the credentials under this id. -->
+                            <publishingServerId>central</publishingServerId>
+                            <!-- Auto-publish after upload validates, instead of
+                                 leaving the deployment in a "validated" state that
+                                 would require a manual click in the Central Portal. -->
+                            <autoPublish>true</autoPublish>
+                            <!-- Block until Central confirms the deployment is
+                                 published, so post-deploy CI steps (tag push,
+                                 next-snapshot bump) only run on a real success. -->
+                            <waitUntil>published</waitUntil>
                         </configuration>
-                        <executions>
-                            <execution>
-                                <id>deploy-to-sonatype</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                    <goal>release</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -200,14 +199,4 @@
         <developerConnection>scm:git:https://github.com/jarlah/testcontainers-ceph.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
## Summary

The last release attempt failed with `401 Unauthorized` against `https://s01.oss.sonatype.org/`. That host (legacy OSSRH) was sunset by Sonatype on **2025-06-30** — about 10 months ago. Sonatype migrated everything to the new **Central Publishing Portal** (`central.sonatype.com`), and the staging plugin we relied on is no longer maintained.

This PR migrates the release pipeline to the new system.

### Changes
- `pom.xml`: replace `nexus-staging-maven-plugin` (1.7.0) with `central-publishing-maven-plugin` (0.7.0). Configured with `autoPublish=true` and `waitUntil=published` so the CI step blocks on Central confirming the deployment, instead of leaving a "validated" deployment that needs a manual click.
- `pom.xml`: drop `<distributionManagement>` — the Central plugin doesn't use it.
- `.github/workflows/publish.yaml`: change `setup-java` `server-id` from `s01.oss.sonatype.org` → `central` (matches `<publishingServerId>` in the pom).
- `.github/workflows/publish.yaml`: rename the publish step's env vars to `CENTRAL_USERNAME` / `CENTRAL_TOKEN`. These are functionally different credentials (Central Portal user token, not the legacy OSSRH password), so reusing the old secret names would have been misleading.

### Things that did NOT change
- **PGP signing** stays exactly as before. Central still verifies `.asc` signatures against the public keyservers — signing requirements were not relaxed in the migration.
- The GPG diagnostic step in the workflow is unchanged.
- The release/idempotency/tag-push logic is unchanged.

## Required action before merging

Add two new repository secrets in **Settings → Secrets and variables → Actions**:

- `CENTRAL_USERNAME` — the random username from "Generate User Token" on `central.sonatype.com` (top-right avatar → View Account → Generate User Token)
- `CENTRAL_TOKEN` — the random password shown alongside it (only shown once; capture both immediately)

The old `OSSRH_USERNAME` / `OSSRH_TOKEN` secrets can stay or be deleted — nothing references them anymore.

Namespace `io.github.jarlah` is already verified on the Central Portal (confirmed via the publishing settings page), so no namespace work is required.

## Test plan

- [x] Add `CENTRAL_USERNAME` and `CENTRAL_TOKEN` secrets
- [ ] Merge this PR
- [ ] Trigger `release-to-maven-central` workflow with a real release version (e.g. 2.0.8) and the next snapshot version (e.g. 2.0.9-SNAPSHOT)
- [ ] Confirm the artifact appears on `https://central.sonatype.com/artifact/io.github.jarlah/testcontainers-ceph` and is searchable on `search.maven.org` within ~30 minutes
- [ ] Confirm the release commit + tag landed on `main` and the next-snapshot bump committed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)