### PR TITLE
Consolidate pending Dependabot dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,11 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Maven Central Release tools -->
-        <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
-        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
-        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+        <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     </properties>
 
 
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.6</version>
             </plugin>
         </plugins>
     </build>
@@ -147,25 +147,25 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-            <version>2.30.32</version>
+            <version>2.48.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.25</version>
+            <version>1.5.38</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.17</version>
+            <version>1.5.38</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
+            <version>2.0.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -183,13 +183,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.6</version>
+            <version>2.22.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.18.3</version>
+            <version>2.22</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- Bundles the still-current open Dependabot PRs into a single bump: AWS SDK S3 2.30.32→2.48.4, logback-core/logback-classic 1.5.25/1.5.17→1.5.38, slf4j-api 2.0.17→2.0.18, jackson-core 2.18.6→2.22.1, jackson-annotations 2.18.3→2.22, and the Maven Central release tooling (versions-maven-plugin 2.18.0→2.21.0, maven-gpg-plugin 3.2.7→3.2.8, maven-source-plugin 3.3.1→3.4.0, maven-javadoc-plugin 3.11.2→3.12.0, central-publishing-maven-plugin 0.7.0→0.11.0, maven-surefire-plugin 3.5.2→3.5.6).
- Left out several open Dependabot branches whose target versions have already been superseded by manual bumps on `main` (they're stale/no-ops or downgrades relative to `main` today): `testcontainers-1.20.5`, `awssdk-s3-2.30.32`, `junit-jupiter-engine-5.12.0`, `slf4j-api-2.0.17`, `assertj-core-3.27.3`, `jackson-core-2.18.3`, `jackson-annotations-2.18.3`, `logback-classic-1.5.17`, `logback-core-1.5.17`, `maven-javadoc-plugin-3.11.2`. These are safe to close as superseded.
- Deliberately excluded `junit-jupiter-engine` 5.12.0→6.1.2: JUnit 6 raises the minimum Java version to 17, which would break this project's Java 11 target and the 11/17/21/25 CI matrix. That needs its own decision about dropping Java 11 support, not a routine dependency bump.

## Test plan
- [x] `./mvnw -B test` — 7/7 tests pass (spins up the real Ceph testcontainer via Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)