### PR TITLE
Bump junit-jupiter-engine to 6.1.2 and raise Java baseline to 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 11, 17, 21, 25 ]
+        java-version: [ 17, 21, 25 ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           # `central` matches <publishingServerId> in pom.xml; the legacy
           # `s01.oss.sonatype.org` host is dead (OSSRH was sunset 2025-06-30).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Backed by the official [`quay.io/ceph/demo`](https://quay.io/repository/ceph/dem
 
 ## Requirements
 
-- Java 11+
+- Java 17+
 - Docker (or a compatible daemon — Podman / Colima / Docker Desktop / Rancher Desktop / Testcontainers Cloud)
 
 ## Installation
@@ -241,7 +241,7 @@ new CephContainer().waitingFor(Wait.forListeningPort());
 
 ## Contributing
 
-Issues and PRs welcome. The repo ships a Nix dev shell — `nix develop` (or `direnv allow`) gives you JDK 11, Maven, and the Docker CLI, so you don't need to install the toolchain on your host.
+Issues and PRs welcome. The repo ships a Nix dev shell — `nix develop` (or `direnv allow`) gives you JDK 17, Maven, and the Docker CLI, so you don't need to install the toolchain on your host.
 
 Run the test suite with:
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        jdk = pkgs.jdk11;
+        jdk = pkgs.jdk17;
       in
       {
         devShells.default = pkgs.mkShell {

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
         </developer>
     </developers>
     <properties>
-        <java.version>11</java.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.12.0</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> { } }:
 
 let
-  jdk = pkgs.jdk11;
+  jdk = pkgs.jdk17;
 in
 pkgs.mkShell {
   packages = [


### PR DESCRIPTION
## Summary
- Bumps `org.junit.jupiter:junit-jupiter-engine` from 5.12.0 to 6.1.2 (same change proposed in #265)
- JUnit 6 requires Java 17+, so also raises the project baseline from Java 11 to 17: `pom.xml` compiler source/target, CI workflow matrices (`maven.yml`, `publish.yaml`), Nix dev shells (`flake.nix`, `shell.nix`), and the README
- Closes #265, which only bumped the dependency and would have broken the build under Java 11

## Test plan
- [x] `mvn test` — all 7 tests in `CephContainerTest` pass, build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)